### PR TITLE
Add Employee entity lifecycle management with auditing and soft delete

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM eclipse-temurin:21-jdk-alpine
+
+WORKDIR /app
+
+# built JAR file into the container
+COPY target/entity-lifecycle-0.0.1-SNAPSHOT.jar app.jar
+
+# Exposed the port your Spring Boot app runs on
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -74,16 +74,6 @@ Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityL
 
 ---
 
-## Getting Started
-
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com.mcas.ms/NashTech-Labs/spring-data-jpa-entity-lifecycle
-   cd spring-data-jpa-entity-lifecycle
-   ```
-2. **Run the application**
----
-
 ## Entity Auditing
 
 Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityListener` to log lifecycle events such as creation, modification, and deletion timestamps.

--- a/README.md
+++ b/README.md
@@ -74,24 +74,6 @@ Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityL
 
 ---
 
-## Entity Auditing
-
-Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityListener` to log lifecycle events such as creation, modification, and deletion timestamps.
-
----
-
-## Tech Stack
-
-- Java 17+
-- Spring Boot
-- Spring Data JPA
-- H2 (in-memory DB for development)
-- Lombok
-- OpenAPI/Swagger (springdoc-openapi)
-- JUnit & Mockito
-
----
-
 ## Getting Started
 
 1. **Clone the repository**
@@ -107,6 +89,8 @@ Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityL
 
    - Swagger UI: http://localhost:8080/swagger-ui.html
    - H2 Console: http://localhost:8080/h2-console
+
+---
 
 ## Running Tests
 To execute unit tests:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# spring-jpa-entity-lifecycle
+# Spring Data JPA Entity Lifecycle Demo
+
+This is a Spring Boot project that demonstrates the lifecycle of JPA entities with auditing, clean architecture, and robust exception handling. The core functionality revolves around managing `Employee` entities using Spring Data JPA, and capturing their lifecycle events (create, update, delete) via entity listeners.
+
+---
+
+## Project Structure
+```bash
+    spring-data-jpa-entity-lifecycle/
+    ├── src/
+    │ ├── main/
+    │ │ ├── java/com/nashtech/techhub/
+    │ │ │ ├── EntityLifecycleApplication.java
+    │ │ │ ├── audit/ # Auditing entity and listener
+    │ │ │ ├── config/ # OpenAPI & JPA configuration
+    │ │ │ ├── controller/ # REST controller for employee operations
+    │ │ │ ├── dto/ # Request/Response DTOs
+    │ │ │ ├── entity/ # JPA entity (Employee)
+    │ │ │ ├── exception/ # Global and custom exceptions
+    │ │ │ ├── repository/ # Spring Data repository
+    │ │ │ └── services/ # Service layer with interface and implementation
+    │ │ └── resources/
+    │ │ └── application.yml # Application configuration
+    │ └── test/
+    │ └── java/com/nashtech/techhub/
+    │ ├── EntityLifecycleApplicationTests.java
+    │ └── service/EmployeeServiceTest.java #Unit Test Cases
+```
+
+---
+
+## Features
+
+- CRUD operations for `Employee`
+- JPA Auditing using `@EntityListeners`
+- Clean layering: Controller → Service → Repository
+- DTO usage for request/response isolation
+- Global exception handling with custom exceptions
+- API documentation via Springdoc OpenAPI
+- Unit tests with JUnit and Mockito
+
+---
+
+## Endpoints
+
+| Method | Endpoint             | Description                        |
+|--------|----------------------|------------------------------------|
+| GET    | `/api/employees`     | Get all **active** employees       |
+| POST   | `/api/employees`     | Create a new employee              |
+| PUT    | `/api/employees/{id}`| Update an existing employee        |
+| DELETE | `/api/employees/{id}`| **Soft delete** an employee by ID  |
+
+OpenAPI Swagger UI available at:  
+`http://localhost:8080/swagger-ui.html`
+
+
+---
+
+## Entity Auditing
+
+Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityListener` to log lifecycle events such as creation, modification, and deletion timestamps.
+
+---
+
+## Tech Stack
+
+- Java 17+
+- Spring Boot
+- Spring Data JPA
+- H2 (in-memory DB for development)
+- Lombok
+- OpenAPI/Swagger (springdoc-openapi)
+- JUnit & Mockito
+
+---
+
+## Getting Started
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com.mcas.ms/NashTech-Labs/spring-data-jpa-entity-lifecycle
+   cd spring-data-jpa-entity-lifecycle
+   ```
+2. **Run the application**
+---
+
+## Entity Auditing
+
+Each `Employee` entity extends `AuditableEntity` and is tracked by `AuditEntityListener` to log lifecycle events such as creation, modification, and deletion timestamps.
+
+---
+
+## Tech Stack
+
+- Java 17+
+- Spring Boot
+- Spring Data JPA
+- H2 (in-memory DB for development)
+- Lombok
+- OpenAPI/Swagger (springdoc-openapi)
+- JUnit & Mockito
+
+---
+
+## Getting Started
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com.mcas.ms/NashTech-Labs/spring-data-jpa-entity-lifecycle
+   cd spring-data-jpa-entity-lifecycle
+   ```
+2. **Run the application**
+    ```bash
+    ./mvnw spring-boot:run
+   ```
+3. **Access API docs**
+
+   - Swagger UI: http://localhost:8080/swagger-ui.html
+   - H2 Console: http://localhost:8080/h2-console
+
+## Running Tests
+To execute unit tests:
+```bash
+./mvnw test
+   ```

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.6</version>
+		<relativePath/>
+	</parent>
+	<groupId>com.nashtech.techhub</groupId>
+	<artifactId>entity-lifecycle</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>entity-lifecycle</name>
+	<description>JPA entity life cycle project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JUnit 5 (Jupiter) -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Mockito for Mocking Dependencies -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/nashtech/techhub/EntityLifecycleApplication.java
+++ b/src/main/java/com/nashtech/techhub/EntityLifecycleApplication.java
@@ -1,0 +1,13 @@
+package com.nashtech.techhub;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EntityLifecycleApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(EntityLifecycleApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/nashtech/techhub/audit/AuditEntityListener.java
+++ b/src/main/java/com/nashtech/techhub/audit/AuditEntityListener.java
@@ -1,0 +1,28 @@
+package com.nashtech.techhub.audit;
+
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+
+/**
+ * JPA Entity Listener for auditing purposes.
+ * Automatically sets creation and update timestamps on entities
+ * that extend {@link AuditableEntity} during persistence lifecycle events.
+ */
+public class AuditEntityListener {
+    @PrePersist
+    public void setCreatedAt(Object entity) {
+        if (entity instanceof AuditableEntity auditable) {
+            LocalDateTime now = LocalDateTime.now();
+            auditable.setCreatedTime(now);
+            auditable.setUpdatedTime(now);
+        }
+    }
+
+    @PreUpdate
+    public void setUpdatedAt(Object entity) {
+        if (entity instanceof AuditableEntity auditable) {
+            auditable.setUpdatedTime(LocalDateTime.now());
+        }
+    }
+}

--- a/src/main/java/com/nashtech/techhub/audit/AuditableEntity.java
+++ b/src/main/java/com/nashtech/techhub/audit/AuditableEntity.java
@@ -1,0 +1,40 @@
+package com.nashtech.techhub.audit;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import java.time.LocalDateTime;
+
+/**
+ * Abstract base class for audit-related fields.
+ * Provides createdTime, updatedTime, deletedTime, and isDeleted flags.
+ * Automatically populated using {@link AuditEntityListener}.
+ */
+@MappedSuperclass
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EntityListeners(AuditEntityListener.class)
+public abstract class AuditableEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdTime;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedTime;
+
+    @JsonIgnore
+    protected LocalDateTime deletedTime;
+
+    @JsonIgnore
+    protected boolean isDeleted = false;
+}

--- a/src/main/java/com/nashtech/techhub/config/JpaConfig.java
+++ b/src/main/java/com/nashtech/techhub/config/JpaConfig.java
@@ -1,0 +1,15 @@
+package com.nashtech.techhub.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/**
+ * Configuration class to enable JPA Auditing in the application.
+ * This allows automatic population of auditing fields such as
+ * createdTime and updatedTime in auditable entities.
+ */
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/nashtech/techhub/config/OpenApiConfig.java
+++ b/src/main/java/com/nashtech/techhub/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.nashtech.techhub.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class for setting up OpenAPI (Swagger) documentation.
+ * Defines API metadata and JWT-based bearer authentication scheme.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI employeeServiceOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Employee Management API")
+                        .description("Spring Boot app using JPA lifecycle callbacks for audit and soft delete.")
+                        .version("1.0"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/nashtech/techhub/controller/EmployeeController.java
+++ b/src/main/java/com/nashtech/techhub/controller/EmployeeController.java
@@ -1,0 +1,56 @@
+package com.nashtech.techhub.controller;
+
+import com.nashtech.techhub.dto.EmployeeRequest;
+import com.nashtech.techhub.dto.EmployeeResponse;
+import com.nashtech.techhub.services.EmployeeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST controllers for managing Employee entities.
+ * Provides endpoints for CRUD operations with auditing and soft delete support.
+ */
+@Tag(name = "Employee Management", description = "Operations with audit and soft delete")
+@RestController
+@RequestMapping("api/employees")
+public class EmployeeController {
+
+    private final EmployeeService service;
+
+    public EmployeeController(EmployeeService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Get all active employees")
+    @GetMapping
+    public ResponseEntity<List<EmployeeResponse>> getEmployees() {
+        List<EmployeeResponse> employees = service.getAllActiveEmployees();
+        return ResponseEntity.ok(employees);
+    }
+
+    @Operation(summary = "Create a new employee")
+    @PostMapping
+    public ResponseEntity<EmployeeResponse> create(@Valid @RequestBody EmployeeRequest request) {
+        EmployeeResponse saved = service.createEmployee(request);
+        return ResponseEntity.ok(saved);
+    }
+
+    @Operation(summary = "Update an existing employee")
+    @PutMapping("/{id}")
+    public ResponseEntity<EmployeeResponse> update(@PathVariable Long id, @Valid @RequestBody EmployeeRequest request) {
+        EmployeeResponse updated = service.updateEmployee(id, request);
+        return ResponseEntity.ok(updated);
+    }
+
+    @Operation(summary = "Soft delete an employee")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.softDelete(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/nashtech/techhub/dto/EmployeeRequest.java
+++ b/src/main/java/com/nashtech/techhub/dto/EmployeeRequest.java
@@ -1,0 +1,19 @@
+package com.nashtech.techhub.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO used for creating or updating an Employee.
+ * Includes validation constraints to ensure required fields are provided.
+ */
+@Getter
+@Setter
+public class EmployeeRequest {
+    @NotBlank(message = "Name is required")
+    private String name;
+
+    @NotBlank(message = "Role is required")
+    private String role;
+}

--- a/src/main/java/com/nashtech/techhub/dto/EmployeeResponse.java
+++ b/src/main/java/com/nashtech/techhub/dto/EmployeeResponse.java
@@ -1,0 +1,19 @@
+package com.nashtech.techhub.dto;
+
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO used to return employee information in API responses.
+ * Includes basic details along with audit timestamps.
+ */
+@Data
+public class EmployeeResponse {
+    private Long id;
+    private String name;
+    private String role;
+    private LocalDateTime createdTime;
+    private LocalDateTime updatedTime;
+}

--- a/src/main/java/com/nashtech/techhub/entity/Employee.java
+++ b/src/main/java/com/nashtech/techhub/entity/Employee.java
@@ -1,0 +1,30 @@
+package com.nashtech.techhub.entity;
+
+import com.nashtech.techhub.audit.AuditableEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Entity class representing the Employee table.
+ * Inherits audit fields like createdTime and updatedTime from AuditableEntity.
+ */
+
+@Entity
+@Table(name = "employees")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Employee extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String name;
+
+    private String role;
+
+}

--- a/src/main/java/com/nashtech/techhub/exception/EmployeeNotFoundException.java
+++ b/src/main/java/com/nashtech/techhub/exception/EmployeeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.nashtech.techhub.exception;
+
+public class EmployeeNotFoundException extends RuntimeException{
+    public EmployeeNotFoundException(Long id) {
+        super("Employee not found with ID: " + id);
+    }
+}

--- a/src/main/java/com/nashtech/techhub/exception/ErrorResponse.java
+++ b/src/main/java/com/nashtech/techhub/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.nashtech.techhub.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+/**
+ * A standard structure for error responses sent to clients.
+ * Contains detailed information about the exception and request context.
+ */
+
+@Getter
+@Setter
+public class ErrorResponse {
+
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String message;
+    private String path;
+
+    public ErrorResponse(LocalDateTime timestamp, int status, String error, String message, String path) {
+        this.timestamp = timestamp;
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.path = path;
+    }
+}

--- a/src/main/java/com/nashtech/techhub/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nashtech/techhub/exception/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.nashtech.techhub.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.WebRequest;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+/**
+ * Global exception handler for the application.
+ * Catches and formats exceptions into standardized error responses.
+ */
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EmployeeNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEmployeeNotFound(EmployeeNotFoundException ex, WebRequest request) {
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "NOT_FOUND",
+                ex.getMessage(),
+                request.getDescription(false)
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntime(RuntimeException ex, WebRequest request) {
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "BAD_REQUEST",
+                ex.getMessage(),
+                request.getDescription(false)
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
+        String errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "VALIDATION_FAILED",
+                errors,
+                request.getDescription(false)
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}

--- a/src/main/java/com/nashtech/techhub/repository/EmployeeRepository.java
+++ b/src/main/java/com/nashtech/techhub/repository/EmployeeRepository.java
@@ -1,0 +1,22 @@
+package com.nashtech.techhub.repository;
+
+import com.nashtech.techhub.entity.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository interface for Employee entity.
+ * Extends JpaRepository to provide basic CRUD operations.
+ * Includes custom queries for retrieving non-deleted (active) employees.
+ */
+
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+    @Query("SELECT e FROM Employee e WHERE e.isDeleted = false")
+    List<Employee> findAllActive();
+
+    @Query("SELECT e FROM Employee e WHERE e.id = :id AND e.isDeleted = false")
+    Optional<Employee> findActiveById(Long id);
+}

--- a/src/main/java/com/nashtech/techhub/services/EmployeeService.java
+++ b/src/main/java/com/nashtech/techhub/services/EmployeeService.java
@@ -1,0 +1,17 @@
+package com.nashtech.techhub.services;
+
+import com.nashtech.techhub.dto.EmployeeRequest;
+import com.nashtech.techhub.dto.EmployeeResponse;
+
+import java.util.List;
+
+/*
+* EmployeeService provides interfaces for managing the methods
+*/
+public interface EmployeeService {
+
+    List<EmployeeResponse> getAllActiveEmployees();
+    EmployeeResponse createEmployee(EmployeeRequest request);
+    EmployeeResponse updateEmployee(Long id, EmployeeRequest request);
+    void softDelete(Long id);
+}

--- a/src/main/java/com/nashtech/techhub/services/implementations/EmployeeServiceImpl.java
+++ b/src/main/java/com/nashtech/techhub/services/implementations/EmployeeServiceImpl.java
@@ -1,0 +1,75 @@
+package com.nashtech.techhub.services.implementations;
+
+import com.nashtech.techhub.dto.EmployeeRequest;
+import com.nashtech.techhub.dto.EmployeeResponse;
+import com.nashtech.techhub.entity.Employee;
+import com.nashtech.techhub.exception.EmployeeNotFoundException;
+import com.nashtech.techhub.repository.EmployeeRepository;
+import com.nashtech.techhub.services.EmployeeService;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+    * EmployeeServiceImpl provides method implementations to manage Employees Entities
+    * It interacts with the EmployeeRepository to perform CRUD operations.
+ */
+@Service
+public class EmployeeServiceImpl implements EmployeeService {
+
+    private final EmployeeRepository employeeRepository;
+
+    public EmployeeServiceImpl(EmployeeRepository employeeRepository) {
+        this.employeeRepository = employeeRepository;
+    }
+
+    @Override
+    public List<EmployeeResponse> getAllActiveEmployees() {
+        return employeeRepository.findAllActive()
+                .stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public EmployeeResponse createEmployee(EmployeeRequest request) {
+        Employee employee = new Employee();
+        employee.setName(request.getName());
+        employee.setRole(request.getRole());
+        Employee saved = employeeRepository.save(employee);
+        return mapToResponse(saved);
+    }
+
+    @Override
+    public EmployeeResponse updateEmployee(Long id, EmployeeRequest request) {
+        Employee existing = employeeRepository.findById(id)
+                .orElseThrow(() -> new EmployeeNotFoundException(id));
+        existing.setName(request.getName());
+        existing.setRole(request.getRole());
+        Employee updated = employeeRepository.save(existing);
+        return mapToResponse(updated);
+    }
+
+    @Override
+    public void softDelete(Long id) {
+        Employee existing = employeeRepository.findById(id)
+                .orElseThrow(() -> new EmployeeNotFoundException(id));
+        existing.setDeleted(true);
+        existing.setDeletedTime(LocalDateTime.now());
+        employeeRepository.save(existing);
+    }
+
+
+    // utility method
+    private EmployeeResponse mapToResponse(Employee employee) {
+        EmployeeResponse response = new EmployeeResponse();
+        response.setId(employee.getId());
+        response.setName(employee.getName());
+        response.setRole(employee.getRole());
+        response.setCreatedTime(employee.getCreatedTime());
+        response.setUpdatedTime(employee.getUpdatedTime());
+        return response;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: pass
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+  springdoc:
+    api-docs:
+      enabled: true
+    swagger-ui:
+      enabled: true
+      path: /swagger-ui.html

--- a/src/test/java/com/nashtech/techhub/EntityLifecycleApplicationTests.java
+++ b/src/test/java/com/nashtech/techhub/EntityLifecycleApplicationTests.java
@@ -1,0 +1,13 @@
+package com.nashtech.techhub;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EntityLifecycleApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/nashtech/techhub/service/EmployeeServiceTest.java
+++ b/src/test/java/com/nashtech/techhub/service/EmployeeServiceTest.java
@@ -1,0 +1,157 @@
+package com.nashtech.techhub.service;
+
+import com.nashtech.techhub.dto.EmployeeRequest;
+import com.nashtech.techhub.dto.EmployeeResponse;
+import com.nashtech.techhub.entity.Employee;
+import com.nashtech.techhub.exception.EmployeeNotFoundException;
+import com.nashtech.techhub.repository.EmployeeRepository;
+import com.nashtech.techhub.services.implementations.EmployeeServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link EmployeeServiceImpl} using Unit 5 and Mockito.
+ * This test suite verifies the behavior of the service layer, ensuring
+ * that Employee entities are handled correctly according to business logic.
+ */
+@ExtendWith(MockitoExtension.class)
+class EmployeeServiceTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @InjectMocks
+    private EmployeeServiceImpl employeeService;
+
+    private Employee employee;
+
+    /**
+     * Initializes a sample Employee entity before each test.
+     */
+    @BeforeEach
+    void setup() {
+        employee = new Employee();
+        employee.setId(1L);
+        employee.setName("Aman");
+        employee.setRole("QA");
+        employee.setCreatedTime(LocalDateTime.now());
+        employee.setUpdatedTime(LocalDateTime.now());
+    }
+
+    /**
+     * Test case for fetching all active employees.
+     * Verifies that the repository is queried and the correct response is returned.
+     */
+    @Test
+    void testGetAllActiveEmployees() {
+        when(employeeRepository.findAllActive()).thenReturn(List.of(employee));
+
+        List<EmployeeResponse> responses = employeeService.getAllActiveEmployees();
+
+        assertEquals(1, responses.size());
+        assertEquals("Aman", responses.getFirst().getName());
+        verify(employeeRepository, times(1)).findAllActive();
+    }
+
+    /**
+     * Test case for creating a new employee.
+     * Ensures the repository's save method is called and the response is mapped properly.
+     */
+    @Test
+    void testCreateEmployee() {
+        EmployeeRequest request = new EmployeeRequest();
+        request.setName("John");
+        request.setRole("Dev");
+
+        Employee saved = new Employee();
+        saved.setId(2L);
+        saved.setName("John");
+        saved.setRole("Dev");
+
+        when(employeeRepository.save(any(Employee.class))).thenReturn(saved);
+
+        EmployeeResponse response = employeeService.createEmployee(request);
+
+        assertEquals("John", response.getName());
+        assertEquals("Dev", response.getRole());
+        verify(employeeRepository).save(any(Employee.class));
+    }
+
+    /**
+     * Test case for updating an existing employee.
+     * Ensures existing employee is found, updated, and saved correctly.
+     */
+    @Test
+    void testUpdateEmployee() {
+        EmployeeRequest request = new EmployeeRequest();
+        request.setName("Updated Name");
+        request.setRole("Lead");
+
+        when(employeeRepository.findById(1L)).thenReturn(Optional.of(employee));
+        when(employeeRepository.save(any(Employee.class))).thenReturn(employee);
+
+        EmployeeResponse response = employeeService.updateEmployee(1L, request);
+
+        assertEquals("Updated Name", response.getName());
+        assertEquals("Lead", response.getRole());
+        verify(employeeRepository).save(employee);
+    }
+
+    /**
+     * Test case for updating an employee that does not exist.
+     * Expects EmployeeNotFoundException to be thrown.
+     */
+    @Test
+    void testUpdateEmployee_NotFound() {
+        when(employeeRepository.findById(999L)).thenReturn(Optional.empty());
+
+        EmployeeRequest request = new EmployeeRequest();
+        request.setName("Ghost");
+        request.setRole("None");
+
+        assertThrows(EmployeeNotFoundException.class, () ->
+                employeeService.updateEmployee(999L, request));
+    }
+
+    /**
+     * Test case for soft deleting an existing employee.
+     * Verifies that the 'deleted' flag and timestamp are set.
+     */
+    @Test
+    void testSoftDeleteEmployee() {
+        when(employeeRepository.findById(1L)).thenReturn(Optional.of(employee));
+
+        employeeService.softDelete(1L);
+
+        ArgumentCaptor<Employee> captor = ArgumentCaptor.forClass(Employee.class);
+        verify(employeeRepository).save(captor.capture());
+
+        Employee softDeleted = captor.getValue();
+        assertTrue(softDeleted.isDeleted());
+        assertNotNull(softDeleted.getDeletedTime());
+    }
+
+    /**
+     * Test case for soft deleting a non-existing employee.
+     * Expects EmployeeNotFoundException to be thrown.
+     */
+    @Test
+    void testSoftDeleteEmployee_NotFound() {
+        when(employeeRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(EmployeeNotFoundException.class, () ->
+                employeeService.softDelete(999L));
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds core functionality for managing Employee entities with:

- CRUD operations using Spring Data JPA
- Soft delete support
- Auditing via @EntityListeners (createdAt, updatedAt)
- Layered architecture (Controller → Service → Repository)
- DTOs for clean request/response handling
- Global exception handling
- OpenAPI (Swagger UI) integration

### API docs

- Swagger UI: `http://localhost:8080/swagger-ui.html`
- Includes unit test setup (`EmployeeServiceTest`)
- Uses `application.yml` for config